### PR TITLE
Remove various redundancies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -23,11 +23,12 @@
         "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "libvte",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.acc.umu.se/pub/gnome/sources/vte/0.52/vte-0.52.2.tar.xz",
-                    "sha256": "0f2657cef52accbfe56feede553155552d7c1984b1291838af3cb8cfc19b26af"
+                    "url": "http://ftp.acc.umu.se/pub/gnome/sources/vte/0.58/vte-0.58.0.tar.xz",
+                    "sha256": "0705571d81f74e60d8dbeb5bf3658bfc6c3d84cf27a67a30ee7de6a693fadb45"
                 }
             ]
         },

--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -19,33 +19,7 @@
         "--filesystem=xdg-run/dconf",
         "--filesystem=~/.config/dconf:ro"
     ],
-    "build-options": {
-        "cflags": "-O2",
-        "cxxflags": "-O2"
-    },
-
     "modules": [
-        {
-            "name": "gnupg",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.11.tar.bz2",
-                    "sha256": "496c3e123ef53f35436ddccca58e82acaa901ca4e21174e77386c0cea0c49cd9"
-                }
-            ]
-        },
-        {
-            "name": "openssh",
-            "config-opts": ["--without-pie"],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.9p1.tar.gz",
-                    "sha256": "6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad"
-                }
-            ]
-        },
         {
             "name": "libvte",
             "sources": [

--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -20,6 +20,7 @@
         "--filesystem=~/.config/dconf:ro"
     ],
     "modules": [
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "libvte",
             "sources": [


### PR DESCRIPTION
Selected buildflags are automatically passed during build therefore redundant.

Remove gnupg and openssh which are available in Platform. Bundled openssh was vulnerable to multiple CVE: https://nvd.nist.gov/vuln/search/results?form_type=Advanced&cves=on&cpe_version=cpe%3a%2fa%3aopenbsd%3aopenssh%3a7.9%3ap1