### PR TITLE
Update modules

### DIFF
--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -37,7 +37,7 @@
                         "type": "git",
                         "url": "https://github.com/sass/sassc.git",
                         "tag": "3.6.2",
-                        "commit": "66f0ef37e7f0ad3a65d2f481eff09d09408f42d0",
+                        "commit": "66f0ef37e7f0ad3a65d2f481eff09d09408f42d0"
                     },
                     {
                         "type": "script",

--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -111,7 +111,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/elementary/granite.git",
-                    "tag": "6.2.0"
+                    "tag": "6.2.0",
                     "commit": "4ab145c28bb3db6372fe519e8bd79c645edfcda3"
                 }
             ]

--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -20,9 +20,10 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/elementary/stylesheet/archive/refs/tags/6.1.0.tar.gz",
-                    "sha256": "9a4181f90d7d4728236a83ceba7aaac9d1dca608016b0e7a636f848ea316436a"
+                    "type": "git",
+                    "url": "https://github.com/elementary/stylesheet.git",
+                    "tag": "6.1.1",
+                    "commit": "d590af0633bb1a311fee3756fcd7b5fdafa9c491"
                 }
             ],
             "modules": [
@@ -35,7 +36,8 @@
                     {
                         "type": "git",
                         "url": "https://github.com/sass/sassc.git",
-                        "tag": "3.6.1"
+                        "tag": "3.6.2",
+                        "commit": "66f0ef37e7f0ad3a65d2f481eff09d09408f42d0",
                     },
                     {
                         "type": "script",
@@ -55,7 +57,8 @@
                         {
                             "type": "git",
                             "url": "https://github.com/sass/libsass.git",
-                            "tag": "3.6.4"
+                            "tag": "3.6.5",
+                            "commit": "f6afdbb9288d20d1257122e71d88e53348a53af3"
                         },
                         {
                             "type": "script",
@@ -78,9 +81,10 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/elementary/icons/archive/refs/tags/6.0.0.tar.gz",
-                    "sha256": "16f5da1788a857c96315a1f0fc5ae18f8ab2868973c3f8e52e6dc3b065f95280"
+                    "type": "git",
+                    "url": "https://github.com/elementary/icons.git",
+                    "tag": "6.1.0",
+                    "commit": "c6cf4636ea0de92c3512242dbf4ec6fb33456b13"
                 }
             ],
             "modules": [
@@ -91,9 +95,10 @@
                 ],
                 "sources": [
                     {
-                        "type": "archive",
-                        "url": "https://gitlab.freedesktop.org/xorg/app/xcursorgen/-/archive/xcursorgen-1.0.7/xcursorgen-xcursorgen-1.0.7.tar.gz",
-                        "sha256": "7fb30a052b63e3ed02c9e43bd70fe1bf8189f2f3d702ab43b5b0726a2dbafccd"
+                        "type": "git",
+                        "url": "https://gitlab.freedesktop.org/xorg/app/xcursorgen",
+                        "tag": "xcursorgen-1.0.7",
+                        "commit": "291d9a052aec0ad4a315c09a9af8b451c94ed57a"
                     }
                 ]
                 }
@@ -104,9 +109,10 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/elementary/granite/archive/refs/tags/6.1.2.tar.gz",
-                    "sha256": "87f4cc8dd66ef077997f534ab011cd5c658eae8e1569ccc3def67227e89a5f1d"
+                    "type": "git",
+                    "url": "https://github.com/elementary/granite.git",
+                    "tag": "6.2.0"
+                    "commit": "4ab145c28bb3db6372fe519e8bd79c645edfcda3"
                 }
             ]
         },
@@ -119,20 +125,21 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/vte/0.66/vte-0.66.0.tar.xz",
-                    "sha256": "d0813ac00fb1d74d88851e765f755d496c83e097097358ea1baadb38b37b7b33"
+                    "url": "https://download.gnome.org/sources/vte/0.66/vte-0.66.2.tar.xz",
+                    "sha256": "e89974673a72a0a06edac6d17830b82bb124decf0cb3b52cebc92ec3ff04d976"
                 }
             ]
         },
         {
             "name": "easyssh",
             "buildsystem": "meson",
-            "config-opts": ["-Dlibunity=false", "-Dubuntu-bionic-patched-vte=false", "-Dpatched-vte=true"],
+            "config-opts": ["-Dubuntu-bionic-patched-vte=false", "-Dpatched-vte=true"],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/muriloventuroso/easyssh/archive/refs/tags/1.7.7.tar.gz",
-                    "sha256": "a43565bbc0e1c3796e393ee464bfc5360f09ffee0ed6952f14010d181bfa7c07"
+                    "type": "git",
+                    "url": "https://github.com/muriloventuroso/easyssh.git",
+                    "tag": "1.7.8",
+                    "commit": "d029a52f36bcad7ae28765dc2bfdb819594bcd03"
                 }
             ]
         }


### PR DESCRIPTION
Update all modules to their latest versions. Also switched to use `git` instead of `archive` because it requires sha256 value of release tarball and that needs to be checked by downloading the tarballs which is a little bit annoying 😅 The `git` requires 2 values (`tag` and `commit`) but we can check it from the release page in GitHub.
