### PR TITLE
Update dependencies versions

### DIFF
--- a/com.github.muriloventuroso.easyssh.json
+++ b/com.github.muriloventuroso.easyssh.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.muriloventuroso.easyssh",
     "runtime": "org.gnome.Platform",
-    "runtime-version" : "41",
+    "runtime-version" : "43",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.muriloventuroso.easyssh",
     "finish-args": [
@@ -125,8 +125,8 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/vte/0.66/vte-0.66.2.tar.xz",
-                    "sha256": "e89974673a72a0a06edac6d17830b82bb124decf0cb3b52cebc92ec3ff04d976"
+                    "url": "https://download.gnome.org/sources/vte/0.70/vte-0.70.1.tar.xz",
+                    "sha256": "1f4601cbfea5302b96902208c8f185e5b18b259b5358bc93cf392bf59871c5b6"
                 }
             ]
         },


### PR DESCRIPTION
- Update `org.gnome.Sdk` and `org.gnome.Platform` to the latest version, 43
- Update Vte to the latest version, 0.70.1